### PR TITLE
Downgrade lavalink version in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
 services:
   lavalink:
     container_name: lavalink
-    image: fredboat/lavalink:master
+    image: fredboat/lavalink:3.6.1
     volumes:
       - "./config/lavalink/application.yml:/opt/Lavalink/application.yml:ro"
     restart: unless-stopped


### PR DESCRIPTION
 due to compatibility issues with waterlink

Downgrade lavalink version to 3.6.1 in docker-compose.yml due to compatibility issues with waterlink used in this project.

With the current master tag you would get "waterlink: connection: event bus: unsupported opcode \"ready\" received"

> yuri69_1    | ERRO[2023/05/21 12:18:33 UTC] Lavalink error                                error="waterlink: connection: event bus: unsupported opcode \"ready\" received"
> yuri69_1    | ERRO[2023/05/21 12:18:33 UTC] Lavalink error                                error="waterlink: connection: read tcp 172.22.0.5:50146->172.22.0.4:2333: use of closed network connection"